### PR TITLE
category links directory page, anchor to heading

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -293,7 +293,7 @@ whitelist:
 #  - <base_path>/my-awesome-category/index.html ~> path: /
 category_archive:
   type: jekyll-archives
-  path: /categories/
+  path: /directorycategory/#
 tag_archive:
   type: jekyll-archives
   path: /tags/

--- a/src/_layouts/grid_category.html
+++ b/src/_layouts/grid_category.html
@@ -8,7 +8,7 @@ layout: single
 
 {% for category in categories %}
   <div class="category-section">
-    <h6 style="text-transform: uppercase; font-family: 'IBM Plex Mono', monospace; font-weight: 300; margin-bottom: 1rem;">{{ category }}</h6>
+    <h6 id="{{ category | slugify }}" style="text-transform: uppercase; font-family: 'IBM Plex Mono', monospace; font-weight: 300; margin-bottom: 1rem;padding-top: 1rem;">{{ category }}</h6>
     <div class="grid__wrapper">
       {% assign category_resources = site.resources | where: "category", category | sort: "title" %}
       {% for post in category_resources %}

--- a/src/_layouts/resource.html
+++ b/src/_layouts/resource.html
@@ -11,7 +11,7 @@ search support: true
 <br>
 <br>
 <h6>CATEGORY</h6>
-{{ page.category }}
+<a href="/directorycategory/#{{ page.category | slugify }}">{{ page.category }}</a>
 <br>
 <br>
 <h6>INSTITUTION</h6>


### PR DESCRIPTION
Hi Chris, Just added some minor config & html changes for a lowest-path-of-resistance version of working category links. With this method, if a user clicks a category link on the resource page (either up top or down by the pagination "Previous" / "Next" links), the browser will open the `/directorycategory/` scrolled down to the appropriate category heading using an anchor link (e.g., `/directorycategory/#digital-manuscript-and-rare-book-collections`). The bonus here is that no new pages need to be created or managed. Let me know what you think!
